### PR TITLE
directions link on searched address

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,11 +62,6 @@
                 <li id='legend-five'></li>
               </ol>
               <div class='clear'></div>
-              <li>
-                <label class='radio inline'>
-                  <input type='radio' name='types' class='hidden' id='rbPolygon1'/><!--MODIFY to remove hidden class to show one or more-->
-                </label>
-              </li>
             </ul>
             <!--MODIFY Point layer legend heading, labels, and colors (green, blue, yellow, red, purple) to match Google Fusion Table and maps_lib.js -->
             <h4>

--- a/js/maps_lib.js
+++ b/js/maps_lib.js
@@ -89,32 +89,28 @@ var MapsLib = {
       templateId: 2
     });
 
+    MapsLib.polygon1.setMap(map);
+
     //reset filters
     $("#search_address").val(MapsLib.convertToPlainString($.address.parameter('address')));
     var loadRadius = MapsLib.convertToPlainString($.address.parameter('radius'));
     if (loadRadius != "") $("#search_radius").val(loadRadius);
     else $("#search_radius").val(MapsLib.searchRadius);
-    // $(":checkbox").prop("checked", "checked");   //if active, all checkboxes on by default
+    $(":checkbox").prop("checked", "checked");   //if active, all checkboxes on by default
     $("#result_box").hide();
 
    //-----custom initializers -- default setting to display Polygon1 layer
-    
-    $("#rbPolygon1").attr("checked", "checked"); 
-
     //-----end of custom initializers-------
 
-    //run the default search
-    MapsLib.doSearch();
+    //run the default search if someone entered an address
+
+    var address = $("#search_address").val();
+    if (address != "")
+      MapsLib.doSearch();
   },
 
   doSearch: function(location) {
     MapsLib.clearSearch();
-
-    // MODIFY if needed: shows background polygon layer depending on which checkbox is selected
-    if ($("#rbPolygon1").is(':checked')) {
-      MapsLib.polygon1.setMap(map);
-      // MapsLib.setDemographicsLabels("very low", "low", "moderate", "high", "very high"); //Not needed because polygon layer is never turned off
-    }
 
     var address = $("#search_address").val();
     MapsLib.searchRadius = $("#search_radius").val();
@@ -124,13 +120,13 @@ var MapsLib = {
 //-----custom filters for point data layer
   
     //-- NUMERICAL OPTION - to display and filter a column of numerical data in your Google Fusion Table
-    //     var type_column = "'TypeNum'";
-    // var searchType = type_column + " IN (-1,";
-    // if ( $("#cbType1").is(':checked')) searchType += "1,";
-    // if ( $("#cbType2").is(':checked')) searchType += "2,";
-    // if ( $("#cbType3").is(':checked')) searchType += "3,";
-    // if ( $("#cbType4").is(':checked')) searchType += "4,";
-    // whereClause += " AND " + searchType.slice(0, searchType.length - 1) + ")";
+    var type_column = "'TypeNum'";
+    var searchType = type_column + " IN (-1,";
+    if ( $("#cbType1").is(':checked')) searchType += "1,";
+    if ( $("#cbType2").is(':checked')) searchType += "2,";
+    if ( $("#cbType3").is(':checked')) searchType += "3,";
+    if ( $("#cbType4").is(':checked')) searchType += "4,";
+    whereClause += " AND " + searchType.slice(0, searchType.length - 1) + ")";
     //-------end of custom filters--------
 
     if (address != "") {
@@ -220,8 +216,6 @@ var MapsLib = {
   clearSearch: function() {
     if (MapsLib.searchrecords != null)
       MapsLib.searchrecords.setMap(null);
-    if (MapsLib.polygon1 != null)
-      MapsLib.polygon1.setMap(null);
     if (MapsLib.addrMarker != null)
       MapsLib.addrMarker.setMap(null);
     if (MapsLib.searchRadiusCircle != null)

--- a/js/maps_lib.js
+++ b/js/maps_lib.js
@@ -125,13 +125,13 @@ var MapsLib = {
 //-----custom filters for point data layer
   
     //-- NUMERICAL OPTION - to display and filter a column of numerical data in your Google Fusion Table
-        var type_column = "'TypeNum'";
-    var searchType = type_column + " IN (-1,";
-    if ( $("#cbType1").is(':checked')) searchType += "1,";
-    if ( $("#cbType2").is(':checked')) searchType += "2,";
-    if ( $("#cbType3").is(':checked')) searchType += "3,";
-    if ( $("#cbType4").is(':checked')) searchType += "4,";
-    whereClause += " AND " + searchType.slice(0, searchType.length - 1) + ")";
+    //     var type_column = "'TypeNum'";
+    // var searchType = type_column + " IN (-1,";
+    // if ( $("#cbType1").is(':checked')) searchType += "1,";
+    // if ( $("#cbType2").is(':checked')) searchType += "2,";
+    // if ( $("#cbType3").is(':checked')) searchType += "3,";
+    // if ( $("#cbType4").is(':checked')) searchType += "4,";
+    // whereClause += " AND " + searchType.slice(0, searchType.length - 1) + ")";
     //-------end of custom filters--------
 
     if (address != "") {

--- a/js/maps_lib.js
+++ b/js/maps_lib.js
@@ -37,7 +37,6 @@ var MapsLib = {
   locationColumn:     "Lat",  // in this point data table, must be capitalized "Lat"
 
   map_centroid:       new google.maps.LatLng(41.5,-72.7), //center that your map defaults to
-  locationScope:      "connecticut",      //geographical area appended to all address searches
   recordName:         "result",       //for showing number of results
   recordNamePlural:   "results",
 
@@ -135,8 +134,6 @@ var MapsLib = {
     //-------end of custom filters--------
 
     if (address != "") {
-      if (address.toLowerCase().indexOf(MapsLib.locationScope) == -1)
-        address = address + " " + MapsLib.locationScope;
 
       geocoder.geocode( { 'address': address}, function(results, status) {
         if (status == google.maps.GeocoderStatus.OK) {
@@ -169,6 +166,20 @@ var MapsLib = {
               animation: google.maps.Animation.DROP,
               title:address
             });
+
+            // populate the info window with the searched address and a link to directions
+            MapsLib.addrInfoWindow = new google.maps.InfoWindow({
+                content: "<div style='height: 60px'>" + address + "<br /><a href='https://maps.google.com/maps?f=d&hl=en&geocode=&daddr=" + address.replace(/ /g, '+') + "' target='_blank'>Get directions &raquo;</a></div>"
+            });
+
+            // set click listener
+            google.maps.event.addListener(MapsLib.addrMarker, 'click', function() {
+              MapsLib.addrInfoWindow.open(map,MapsLib.addrMarker);
+            });
+
+            // open by default
+            MapsLib.addrInfoWindow.open(map,MapsLib.addrMarker);
+
           }
 
           whereClause += " AND ST_INTERSECTS(" + MapsLib.locationColumn + ", CIRCLE(LATLNG" + MapsLib.currentPinpoint.toString() + "," + MapsLib.searchRadius + "))";


### PR DESCRIPTION
This pull request adds links to Google Maps for directions.

Demo site / example up here: http://datamade.github.io/mobility-app/#/?address=307%20NICHOLS%20ST%20BRIDGEPORT%2C%20CT&radius=3220

![screen shot 2015-01-12 at 4 07 09 pm](https://cloud.githubusercontent.com/assets/919583/5712099/14851e84-9a75-11e4-87f3-72a19f0e5bf0.png)

When a user searches for an address, an info window is displayed next to the searched address with the address and a link to Google Maps with directions mode enabled:

![screen shot 2015-01-12 at 4 10 15 pm](https://cloud.githubusercontent.com/assets/919583/5712156/857e79e6-9a75-11e4-83bc-94d971d7baac.png)

Other updates:

* Disabled the `locationScope` functionality, as the Google Places address suggest does a pretty good of making sure the full address is specified. Might be a candidate for change in the [original map template](https://github.com/derekeder/FusionTable-Map-Template). Let me know what you think.
* Modified the [Final Point Data Table](https://www.google.com/fusiontables/DataSource?docid=1qk9z46VakTMrA7zLpt8y4SfQos3FGsWhRTrww1yZ#map:id=3) to also include direction links to that location as well. This change didn't require any updates to this code.

@JackDougherty let me know if this is what you're looking for!
